### PR TITLE
Implement watchdog

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,6 +53,9 @@ docker_plugin_rhel: true
 docker_workaround_noIPv6: false
 docker_workaround_promisc: true
 docker_workaround_dns: true
+docker_workaround_watchdog: true
+docker_workaround_watchdog_pool: 60
+docker_workaround_watchdog_limit: 7
 
 # Override any config in daemon.json inside the dict
 docker_config: {}

--- a/files/watchdog.sh
+++ b/files/watchdog.sh
@@ -4,7 +4,7 @@
 
 while true; do
     sleep $POOL
-    exec $CMD &
+    exec $CMD_TEST &
     PID=$!
 
     sleep $LIMIT

--- a/files/watchdog.sh
+++ b/files/watchdog.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Test if a given CMD_TEST command returns within LIMIT seconds every POOL
+# seconds. If it does, executes CMD_OK, otherwise executes CMD_FALSE.
+
+while true; do
+    exec $CMD &
+    PID=$!
+
+    sleep $LIMIT
+    ps -p$PID &>/dev/null
+    OUT=$?
+
+    if [ $OUT -eq 0 ]; then
+        echo -e $MSG_FAIL
+        $CMD_FAIL
+    else
+        $CMD_OK
+    fi
+    sleep $POOL
+done

--- a/files/watchdog.sh
+++ b/files/watchdog.sh
@@ -3,6 +3,7 @@
 # seconds. If it does, executes CMD_OK, otherwise executes CMD_FALSE.
 
 while true; do
+    sleep $POOL
     exec $CMD &
     PID=$!
 
@@ -16,5 +17,4 @@ while true; do
     else
         $CMD_OK
     fi
-    sleep $POOL
 done

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,3 +7,8 @@
     name: docker
     state: restarted
     enabled: yes
+
+- name: restart watchdog
+  service:
+    name: docker-watchdog
+    state: restarted

--- a/tasks/workarounds.yml
+++ b/tasks/workarounds.yml
@@ -12,3 +12,26 @@
     regexp: "^options single-request"
     line: "options single-request"
   when: docker_workaround_dns
+
+- block:
+  - name: install watchdog script
+    copy:
+      src: watchdog.sh
+      dest: "{{ docker_watchdog_path }}"
+      mode: "0755"
+    notify:
+      - restart watchdog
+  - name: install docker watchdog
+    template:
+      src: "{{ item.src }}"
+      dest: "{{ item.dest }}"
+      mode: "0644"
+    with_items:
+      - src: docker_watchdog.env.j2
+        dest: /etc/sysconfig/docker_watchdog
+      - src: docker-watchdog.service.j2
+        dest: /etc/systemd/system/docker-watchdog.service
+    notify:
+      - reload systemd
+      - restart watchdog
+  when: docker_workaround_watchdog

--- a/templates/docker-watchdog.service.j2
+++ b/templates/docker-watchdog.service.j2
@@ -1,0 +1,9 @@
+[Unit]
+Description=Docker Watchdog
+After=network.target
+Requires=docker.service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/sysconfig/docker_watchdog
+ExecStart=/bin/bash {{docker_watchdog_path}}

--- a/templates/docker.service.j2
+++ b/templates/docker.service.j2
@@ -4,6 +4,9 @@ Documentation=http://docs.docker.com
 After=network.target
 Wants=docker-storage-setup.service
 Requires=docker-cleanup.timer
+{% if docker_workaround_watchdog is defined and docker_workaround_watchdog %}
+Requires=docker-watchdog.service
+{% endif %}
 {% if docker_plugin_rhel is defined and docker_plugin_rhel %}
 Requires=rhel-push-plugin.socket
 {% endif %}

--- a/templates/docker_watchdog.env.j2
+++ b/templates/docker_watchdog.env.j2
@@ -1,0 +1,6 @@
+POOL={{ docker_workaround_watchdog_pool }}
+LIMIT={{ docker_workaround_watchdog_limit }}
+CMD_TEST="docker ps"
+CMD_FAIL="systemctl restart docker"
+CMD_OK="true"
+MSG_FAIL="Docker has frozen. Restarting..."

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -20,3 +20,5 @@ docker_defaults_tls:
     tlscert: "{{ docker_certs }}/engine.cert"
     tlskey: "{{ docker_certs }}/engine.key"
     tlsverify: "{{ docker_tls.enabled }}"
+
+docker_watchdog_path: "/usr/bin/watchdog.sh"


### PR DESCRIPTION
This PR implements a further workaround for Docker. This watchdog checks, by default, every 60 seconds if `docker ps` returns (with any exit code) within 7 seconds. If it doesn't, then the watchdog tries to restart Docker.

The watchdog service unit is only called by the docker unit, so if you start or stop the docker service, the same will happen with the watchdog. Also, it is designed **only** to detect the situation where the docker daemon accepts the connection on the control socket but doesn't answer, so even if there's a misconfiguration that prevents the watchdog from reaching the socket, `docker ps` wil exit quickly and will not try to restart the daemon indefinitely.