### PR TITLE
Changing killmode from cgroup to process

### DIFF
--- a/templates/docker.service.j2
+++ b/templates/docker.service.j2
@@ -43,6 +43,6 @@ LimitCORE=infinity
 TimeoutStartSec=0
 Restart=on-abnormal
 MountFlags=slave
-
+KillMode=process
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This PR fixes the Docker Systemd unit file. It changes the killmode from cgroup to process.