### PR TITLE
Live-restore option shouldn't be enforced to true in RHEL

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -8,7 +8,7 @@ docker_defaults:
       - "native.cgroupdriver=systemd"
     hosts:
       - "unix:///var/run/docker.sock"
-    live-restore: true
+    live-restore: false
     log-driver: "journald"
     log-level: "info"
     selinux-enabled: true


### PR DESCRIPTION
Live restore isn't supported in RHEL 7.3, 7.4 and 7.5. So it shouldn't be true by default, as this is a production ready Docker role. Users may customize daemon.json if they want to enable it.